### PR TITLE
更新 hostname 为 snippets.cm.edu.kg，修正代理地址

### DIFF
--- a/proxy_host/_worker.js
+++ b/proxy_host/_worker.js
@@ -1,4 +1,4 @@
-const hostname = "snippets.neib.cn";
+const hostname = "snippets.cm.edu.kg";
 export default {
     async fetch(request, env, ctx) {
         if (request.headers.get('Upgrade') !== 'websocket') {


### PR DESCRIPTION
This pull request updates the proxy hostname in the `proxy_host/_worker.js` file to point to a new domain.

- Changed the `hostname` constant from `"snippets.neib.cn"` to `"snippets.cm.edu.kg"` to update the proxy target.