### PR TITLE
修正最终路径构建逻辑，确保在全局代理情况下正确格式化 URL

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -72,7 +72,7 @@ export default {
                 最终路径 = 全局socks5 ? `/snippets/gs5=${socks5}` : `/snippets/s5=${socks5}`;
             } else if (url.searchParams.has('http') && url.searchParams.get('http') == '') {
                 socks5 = url.searchParams.get('http');
-                最终路径 = 全局socks5 ? `/http=${socks5}?globalproxy` : `/http=${socks5}`;
+                最终路径 = 全局socks5 ? `/http://${socks5}` : `/http=${socks5}`;
             }
             
             const responseHeaders = {


### PR DESCRIPTION
This pull request updates the path construction logic for HTTP proxy URLs in the `_worker.js` file. The change ensures that when the global proxy setting is enabled, the HTTP proxy path is correctly prefixed with `http://` for proper formatting.

Proxy URL handling:

* Updated the construction of the HTTP proxy path to use `http://${socks5}` instead of `/http=${socks5}?globalproxy` when the global proxy is active, improving URL correctness.