### PR TITLE
Beta

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -2764,7 +2764,7 @@ async function subHtml(request, hostLength = hosts.length) {
         let snippetCodeCache = '';
         
         // GitHub代理配置
-        const GITHUB_PROXY = 'http://github.cmliussss.net/';
+        const GITHUB_PROXY = 'https://github.cmliussss.net/';
         
         // 存储当前订阅URL
         let cpurl = '';

--- a/_worker.js
+++ b/_worker.js
@@ -2771,9 +2771,9 @@ async function subHtml(request, hostLength = hosts.length) {
 
         // 源码URL映射
         const snippetUrlMap = {
-            'v': GITHUB_PROXY + 'https://raw.githubusercontent.com/cmliu/CF-Workers-BPSUB/main/snippet/v.js',
-            't12': GITHUB_PROXY + 'https://raw.githubusercontent.com/cmliu/CF-Workers-BPSUB/main/snippet/t12.js', 
-            't13': GITHUB_PROXY + 'https://raw.githubusercontent.com/cmliu/CF-Workers-BPSUB/main/snippet/t13.js'
+            'v': 'https://raw.githubusercontent.com/cmliu/CF-Workers-BPSUB/main/snippet/v.js',
+            't12': 'https://raw.githubusercontent.com/cmliu/CF-Workers-BPSUB/main/snippet/t12.js', 
+            't13': 'https://raw.githubusercontent.com/cmliu/CF-Workers-BPSUB/main/snippet/t13.js'
         };
 
         // 获取当前选中的源码类型
@@ -2788,7 +2788,7 @@ async function subHtml(request, hostLength = hosts.length) {
             const snippetJsUrl = snippetUrlMap[sourceType];
             
             try {
-                const response = await fetch(snippetJsUrl);
+                const response = await fetch(GITHUB_PROXY + snippetJsUrl);
                 if (!response.ok) {
                     throw new Error('获取代码失败');
                 }


### PR DESCRIPTION
This pull request updates how GitHub raw content is fetched in the `subHtml` function in `_worker.js`. The changes ensure all snippet fetches consistently use the configured proxy and update the proxy URL to use HTTPS.

**Proxy configuration and snippet fetching:**

* Changed the `GITHUB_PROXY` URL from HTTP to HTTPS for improved security.
* Updated the `snippetUrlMap` to store raw GitHub URLs directly, and modified the fetch logic to prepend the proxy URL when requesting snippet files. This ensures all snippet fetches go through the proxy. [[1]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL2767-R2776) [[2]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL2791-R2791)