### PR TITLE
优化SOCKS5账号解析逻辑，支持多种路径格式，提升代码灵活性

### DIFF
--- a/snippet/my.js
+++ b/snippet/my.js
@@ -9,9 +9,10 @@ export default {
         const url = new URL(request.url);
         我的SOCKS5账号 = url.searchParams.get('socks5') || url.searchParams.get('http');
         启用SOCKS5全局反代 = url.searchParams.has('globalproxy');
-        if (url.pathname.toLowerCase().includes('/socks5=')) {
-            我的SOCKS5账号 = url.pathname.split('/socks5=')[1];
+        if (url.pathname.toLowerCase().includes('/socks5=') || (url.pathname.includes('/s5=')) || (url.pathname.includes('/gs5='))) {
+            我的SOCKS5账号 = url.pathname.split('5=')[1];
             启用SOCKS5反代 = 'socks5';
+            启用SOCKS5全局反代 = url.pathname.includes('/gs5=') ? true : 启用SOCKS5全局反代;
         } else if (url.pathname.toLowerCase().includes('/http=')) {
             我的SOCKS5账号 = url.pathname.split('/http=')[1];
             启用SOCKS5反代 = 'http';

--- a/snippet/t12.js
+++ b/snippet/t12.js
@@ -20,9 +20,10 @@ export default {
             const url = new URL(访问请求.url);
             我的SOCKS5账号 = url.searchParams.get('socks5') || url.searchParams.get('http');
             启用SOCKS5全局反代 = url.searchParams.has('globalproxy');
-            if (url.pathname.toLowerCase().includes('/socks5=')) {
-                我的SOCKS5账号 = url.pathname.split('/socks5=')[1];
+            if (url.pathname.toLowerCase().includes('/socks5=') || (url.pathname.includes('/s5=')) || (url.pathname.includes('/gs5='))) {
+                我的SOCKS5账号 = url.pathname.split('5=')[1];
                 启用SOCKS5反代 = 'socks5';
+                启用SOCKS5全局反代 = url.pathname.includes('/gs5=') ? true : 启用SOCKS5全局反代;
             } else if (url.pathname.toLowerCase().includes('/http=')) {
                 我的SOCKS5账号 = url.pathname.split('/http=')[1];
                 启用SOCKS5反代 = 'http';

--- a/snippet/t13.js
+++ b/snippet/t13.js
@@ -17,9 +17,10 @@ export default {
             const url = new URL(访问请求.url);
             我的SOCKS5账号 = url.searchParams.get('socks5') || url.searchParams.get('http');
             启用SOCKS5全局反代 = url.searchParams.has('globalproxy');
-            if (url.pathname.toLowerCase().includes('/socks5=')) {
-                我的SOCKS5账号 = url.pathname.split('/socks5=')[1];
+            if (url.pathname.toLowerCase().includes('/socks5=') || (url.pathname.includes('/s5=')) || (url.pathname.includes('/gs5='))) {
+                我的SOCKS5账号 = url.pathname.split('5=')[1];
                 启用SOCKS5反代 = 'socks5';
+                启用SOCKS5全局反代 = url.pathname.includes('/gs5=') ? true : 启用SOCKS5全局反代;
             } else if (url.pathname.toLowerCase().includes('/http=')) {
                 我的SOCKS5账号 = url.pathname.split('/http=')[1];
                 启用SOCKS5反代 = 'http';


### PR DESCRIPTION
This pull request updates the URL parsing logic in three different files to support additional SOCKS5 proxy path patterns and improve global proxy detection. The changes ensure that the code can recognize new URL path formats for proxy configuration and correctly enable global proxy settings when appropriate.

**URL parsing and proxy configuration improvements:**

* Added support for detecting `/s5=` and `/gs5=` path patterns in addition to `/socks5=` when extracting the SOCKS5 account from the URL pathname. (`snippet/my.js`, `snippet/t12.js`, `snippet/t13.js`) [[1]](diffhunk://#diff-d2e01e8ecf7c6918b598591cca3070f4eedf81802b93199cdf1bb0c7c90f25c5L12-R15) [[2]](diffhunk://#diff-68e671f18d3f4325f784ec32267649aaa2b634d1edff13622eee30a19eee737eL23-R26) [[3]](diffhunk://#diff-ae6dfef2b8c1ad377ce3cd246fbdcc05f061325881e5af08f6caab669e008519L20-R23)
* Updated the logic to enable global SOCKS5 proxy (`启用SOCKS5全局反代`) if the pathname contains `/gs5=`, ensuring correct proxy mode selection based on the URL. (`snippet/my.js`, `snippet/t12.js`, `snippet/t13.js`) [[1]](diffhunk://#diff-d2e01e8ecf7c6918b598591cca3070f4eedf81802b93199cdf1bb0c7c90f25c5L12-R15) [[2]](diffhunk://#diff-68e671f18d3f4325f784ec32267649aaa2b634d1edff13622eee30a19eee737eL23-R26) [[3]](diffhunk://#diff-ae6dfef2b8c1ad377ce3cd246fbdcc05f061325881e5af08f6caab669e008519L20-R23)