### PR TITLE
Beta

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -59,8 +59,8 @@ export default {
                 subConverter = subConverter.split("//")[1] || subConverter;
             }
             subConfig = url.searchParams.get('subconfig') || subConfig;
-            const trojan = url.searchParams.get('trojan') || url.searchParams.has('password') || false;
-            const uuid = trojan ? url.searchParams.get('password') : (url.searchParams.get('uuid') || env.UUID);
+            const trojan = url.searchParams.get('trojan') || false;
+            const uuid = url.searchParams.get('uuid') || env.UUID;
             const uuid_json = await getLocalData(bphost, uuid);
             const xhttp = url.searchParams.get('xhttp') || false;
             let 最终路径 = url.searchParams.has('proxyip') ? `/snippets/ip=${url.searchParams.get('proxyip')}` : (proxyIP && proxyIP.trim() !== '') ? `/snippets/ip=${encodeURIComponent(proxyIP)}` : `/snippets`;
@@ -2305,9 +2305,10 @@ async function subHtml(request, hostLength = hosts.length) {
             // 保存当前表单数据
             saveFormData();
             
-            // 获取当前域名
+            // 获取当前域名和协议
             const currentDomain = window.location.host;
-            let url = \`https://\${currentDomain}/sub\`;
+            const currentProtocol = window.location.protocol || 'https:'; // 获取当前协议 (http: 或 https:)
+            let url = \`\${currentProtocol}//\${currentDomain}/sub\`;
             
             const params = new URLSearchParams();
             

--- a/_worker.js
+++ b/_worker.js
@@ -1977,7 +1977,7 @@ async function subHtml(request, hostLength = hosts.length) {
             </div>
             
             <!-- 高级参数设置 -->
-            <div class="section collapsible collapsed">
+            <div class="section collapsible">
                 <div class="section-title" onclick="toggleSection(this)">🔧 节点高级设置</div>
                 <div class="section-content">
                     <div class="form-group">
@@ -1995,7 +1995,9 @@ async function subHtml(request, hostLength = hosts.length) {
                         <div class="example">⚙️ 高级参数说明：
 • ed=2560：启用0-RTT
 • scv：跳过TLS证书验证，适用于双向解析的免费域名
-• 注意：天书13源码不支持ed参数配置
+• xhttp：使用XHTTP协议必须保证域名开启gRPC支持
+• trojan：使用trojan协议并开启验证UUID的话，要求在当前页面填写正确的UUID后再点击复制源码
+• 天书13：不支持ed参数配置
                         </div>
                     </div>
                 </div>
@@ -2058,6 +2060,8 @@ async function subHtml(request, hostLength = hosts.length) {
                 enableEd: document.getElementById('enableEd') ? document.getElementById('enableEd').checked : false,
                 skipCertVerify: document.getElementById('skipCertVerify') ? document.getElementById('skipCertVerify').checked : false,
                 activeTab: currentTab, // 保存当前选中的选项卡
+                // 保存所有可折叠section的状态
+                sectionStates: getSectionStates(),
                 timestamp: Date.now()
             };
             
@@ -2144,6 +2148,11 @@ async function subHtml(request, hostLength = hosts.length) {
                     document.getElementById('globalHttp').dispatchEvent(new Event('change'));
                 }
                 
+                // 恢复section折叠/展开状态
+                if (formData.sectionStates) {
+                    applySectionStates(formData.sectionStates);
+                }
+
                 // 设置高级参数选项
                 if (formData.enableEd !== undefined && document.getElementById('enableEd')) {
                     document.getElementById('enableEd').checked = formData.enableEd;
@@ -2633,10 +2642,47 @@ async function subHtml(request, hostLength = hosts.length) {
             }
         }
         
+        // 获取所有可折叠section的状态
+        function getSectionStates() {
+            const states = {};
+            const sections = document.querySelectorAll('.section.collapsible');
+            sections.forEach((section, index) => {
+                const titleElement = section.querySelector('.section-title');
+                if (titleElement) {
+                    const title = titleElement.textContent.trim();
+                    states[title] = !section.classList.contains('collapsed');
+                }
+            });
+            return states;
+        }
+
+        // 应用section状态
+        function applySectionStates(states) {
+            if (!states) return;
+            
+            const sections = document.querySelectorAll('.section.collapsible');
+            sections.forEach((section, index) => {
+                const titleElement = section.querySelector('.section-title');
+                if (titleElement) {
+                    const title = titleElement.textContent.trim();
+                    if (states.hasOwnProperty(title)) {
+                        const shouldBeExpanded = states[title];
+                        if (shouldBeExpanded) {
+                            section.classList.remove('collapsed');
+                        } else {
+                            section.classList.add('collapsed');
+                        }
+                    }
+                }
+            });
+        }
+
         // 折叠功能
         function toggleSection(element) {
             const section = element.parentElement;
             section.classList.toggle('collapsed');
+            // 状态改变后保存到缓存
+            saveFormData();
         }
         
         // 选项卡切换函数

--- a/snippet/ca110us.js
+++ b/snippet/ca110us.js
@@ -16,7 +16,7 @@ export default {
         } else if (url.pathname.toLowerCase().includes('/http=')) {
             我的SOCKS5账号 = url.pathname.split('/http=')[1];
             启用SOCKS5反代 = 'http';
-        } else if (url.pathname.toLowerCase().includes('/socks:/') || url.pathname.toLowerCase().includes('/socks5:/') || url.pathname.toLowerCase().includes('/http:/')) {
+        } else if (url.pathname.toLowerCase().includes('/socks://') || url.pathname.toLowerCase().includes('/socks5://') || url.pathname.toLowerCase().includes('/http://')) {
             启用SOCKS5反代 = (url.pathname.includes('/http://')) ? 'http' : 'socks5';
             我的SOCKS5账号 = url.pathname.split('://')[1].split('#')[0];
             if (我的SOCKS5账号.includes('@')) {


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the `_worker.js` and `snippet/ca110us.js` files, focusing on enhancing the user experience for advanced settings, ensuring form state persistence, and correcting protocol handling logic. The most significant changes are grouped below.

**User Experience Improvements:**

* The advanced settings section (`节点高级设置`) is now expanded by default, making it more visible to users.
* Added more detailed explanations for advanced parameters, including new notes about `xhttp` and `trojan` protocol requirements.

**Form State Persistence:**

* Implemented logic to save and restore the expanded/collapsed state of all collapsible sections in the form, ensuring users' UI preferences persist across sessions. This includes new helper functions `getSectionStates` and `applySectionStates`, and updates to the form data saving/restoring process. [[1]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bR2063-R2064) [[2]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bR2151-R2155) [[3]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bR2646-R2686)

**Protocol and Parameter Handling Fixes:**

* Corrected the logic for determining the `trojan` protocol and the handling of the `uuid` parameter, ensuring that `uuid` is only set from the appropriate source.
* Fixed the construction of the subscription URL to dynamically use the current protocol (`http:` or `https:`), improving compatibility in different deployment scenarios.
* Updated SOCKS5/HTTP proxy path matching in `snippet/ca110us.js` to correctly detect protocol prefixes with double slashes (e.g., `/socks://`, `/http://`).