### PR TITLE
添加访问地址检查，增强安全性

### DIFF
--- a/snippet/ca110us.js
+++ b/snippet/ca110us.js
@@ -99,6 +99,7 @@ async function trojanOverWSHandler(request) {
                 throw new Error(message);
                 return;
             }
+            if (addressRemote.includes(atob('c3BlZWQuY2xvdWRmbGFyZS5jb20='))) throw new Error('Access');
             handleTCPOutBound(remoteSocketWapper, addressRemote, portRemote, rawClientData, webSocket);
         },
         close() {

--- a/snippet/my.js
+++ b/snippet/my.js
@@ -77,7 +77,7 @@ async function handleXhttp(request) {
     if (!vlessHeader) return new Response('Invalid VLESS header', {
         status: 400
     });
-
+    if (vlessHeader.hostname.includes(atob('c3BlZWQuY2xvdWRmbGFyZS5jb20='))) throw new Error('Access');
     // 连接到远程
     let remote = null;
     if (启用SOCKS5反代 == 'socks5' && 启用SOCKS5全局反代) {
@@ -223,7 +223,7 @@ async function handleWebSocket(request) {
                 for (let i = 0; i < 8; i++, pos += 2) ipv6.push(view.getUint16(pos).toString(16));
                 addr = ipv6.join(':');
             } else return;
-
+            if (addr.includes(atob('c3BlZWQuY2xvdWRmbGFyZS5jb20='))) throw new Error('Access');
             const header = new Uint8Array([data[0], 0]);
             const payload = data.slice(pos);
 

--- a/snippet/t13.js
+++ b/snippet/t13.js
@@ -134,6 +134,7 @@ async function 启动传输管道(WS接口, TCP接口) {
                 default:
                     throw new Error('无效的访问地址');
             }
+            if (访问地址.includes(atob('c3BlZWQuY2xvdWRmbGFyZS5jb20='))) throw new Error('Access');
             if (启用SOCKS5反代 == 'socks5' && 启用SOCKS5全局反代) {
                 TCP接口 = await 创建SOCKS5接口(识别地址类型, 访问地址, 访问端口);
             } else if (启用SOCKS5反代 == 'http' && 启用SOCKS5全局反代) {
@@ -198,7 +199,7 @@ globalThis.DNS缓存记录 = globalThis.DNS缓存记录 ??= new Map();
 async function 创建SOCKS5接口(识别地址类型, 访问地址, 访问端口, 转换访问地址, 传输数据, 读取数据) {
     let SOCKS5接口, 账号, 密码, 地址, 端口;
     try {
-        ({ 账号, 密码, 地址, 端口 } = await 获取SOCKS5账号(我的SOCKS5账号));
+        ({ username: 账号, password: 密码, hostname: 地址, port: 端口 } = await 获取SOCKS5账号(我的SOCKS5账号));
         SOCKS5接口 = connect({ hostname: 地址, port: 端口 });
         await SOCKS5接口.opened;
         传输数据 = SOCKS5接口.writable.getWriter();

--- a/snippet/v.js
+++ b/snippet/v.js
@@ -135,9 +135,8 @@ async function handleSPESSWebSocket(request, config) {
                 return;
             }
             const result = parseVLESSHeader(chunk);
-            if (result.hasError) {
-                throw new Error(result.message);
-            }
+            if (result.hasError) throw new Error(result.message);
+            if (result.addressRemote.includes(atob('c3BlZWQuY2xvdWRmbGFyZS5jb20='))) throw new Error('Access');
             const vlessRespHeader = new Uint8Array([result.vlessVersion[0], 0]);
             const rawClientData = chunk.slice(result.rawDataIndex);
             if (result.isUDP) {


### PR DESCRIPTION
This pull request introduces access control checks across several modules to block connections to a specific domain, and refactors the SOCKS5 account parsing logic for improved robustness and clarity. The most important changes are grouped below.

**Access Control Enhancements:**

* Added checks in multiple handlers (`trojanOverWSHandler`, `handleXhttp`, `handleWebSocket`, `解析VL标头`, `启动传输管道`, and `handleSPESSWebSocket`) to block requests containing the domain `speed.cloudflare.com` by throwing an "Access" error if the address or hostname includes this value. This prevents connections to a restricted domain throughout the codebase. [[1]](diffhunk://#diff-276290b95ff20ad937d75021b21cc3d6827edcced084059294d0ffee4559a12cR102) [[2]](diffhunk://#diff-d2e01e8ecf7c6918b598591cca3070f4eedf81802b93199cdf1bb0c7c90f25c5L80-R80) [[3]](diffhunk://#diff-d2e01e8ecf7c6918b598591cca3070f4eedf81802b93199cdf1bb0c7c90f25c5L226-R226) [[4]](diffhunk://#diff-68e671f18d3f4325f784ec32267649aaa2b634d1edff13622eee30a19eee737eR153) [[5]](diffhunk://#diff-ae6dfef2b8c1ad377ce3cd246fbdcc05f061325881e5af08f6caab669e008519R137) [[6]](diffhunk://#diff-a65c45ad0e1b0217fa9821b59250aae2cdd438aaca0a598fc71b4ed972cb60f5L138-R139)

**SOCKS5 Account Parsing Refactor:**

* Refactored the `获取SOCKS5账号` function to robustly parse SOCKS5 account strings, supporting both IPv4 and IPv6 formats, validating port numbers, enforcing correct IPv6 bracket usage, and returning a standardized object with `username`, `password`, `hostname`, and `port` fields.
* Updated all usages of `获取SOCKS5账号` to destructure the new return format (`username`, `password`, `hostname`, `port`) instead of the previous (`账号`, `密码`, `地址`, `端口`). [[1]](diffhunk://#diff-68e671f18d3f4325f784ec32267649aaa2b634d1edff13622eee30a19eee737eL295-R296) [[2]](diffhunk://#diff-ae6dfef2b8c1ad377ce3cd246fbdcc05f061325881e5af08f6caab669e008519L201-R202)