### PR TITLE
优化订阅转换后端版本检查逻辑，简化代码结构

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -2506,10 +2506,7 @@ async function subHtml(request, hostLength = 0, FileName, subProtocol, subConver
                 } else {
                     input.value = this.value;
                     input.style.display = 'none';
-                    // 只有非默认后端才检查版本
-                    if (this.value !== DEFAULT_SUBAPI) {
-                        checkSubApiVersion(this.value);
-                    }
+                    checkSubApiVersion(this.value);
                 }
                 saveFormData();
             });


### PR DESCRIPTION
This pull request makes a small change to the `subHtml` function in `_worker.js`. The code now always checks the sub API version, regardless of whether the selected value is the default backend or not. 

- Always call `checkSubApiVersion` when the input value changes, removing the previous condition that skipped the check for the default backend.