### PR TITLE
更新 README.md，添加对 AK 优化源码的引用；修改 _worker.js 和 ak.js 中的 WebSocket 处理逻辑以支…

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,3 +215,4 @@ A: 设置 `PS` 环境变量，或在优选IP中使用 `#备注` 格式
 - [Mingyu](https://github.com/ymyuuu/workers-vless)：ws+xhttp代码
 - [ca110us](https://github.com/ca110us/epeius)：trojan代码
 - [Alexandre Kojève](https://t.me/Enkelte_notif/784)：stallTCP优化
+- @houyiTFG：天书作者

--- a/_worker.js
+++ b/_worker.js
@@ -2080,7 +2080,7 @@ async function subHtml(request, hostLength = 0, FileName, subProtocol, subConver
                                     <select id="snippetSourceSelect" onchange="changeSnippetSource()">
                                         <option value="v" selected>🎯 白嫖哥源码</option>
                                         <option value="t12">📘 天书12源码</option>
-                                        <option value="t13">📗 天书13源码(不支持ios客户端、ed配置)</option>
+                                        <option value="t13">📗 天书13源码(不支持ed配置)</option>
                                         <option value="my">🔥 ymyuuu源码(支持xhttp协议)</option>
                                         <option value="ca110us">🎠 ca110us源码(trojan协议)</option>
                                         <option value="ak">😂 AK优化源码(stallTCP优化传输机制)</option>

--- a/snippet/my.js
+++ b/snippet/my.js
@@ -200,6 +200,7 @@ async function handleWebSocket(request) {
             }
 
             const view = new DataView(data);
+            const version = view.getUint8(0); // 提取版本号
             const optLen = view.getUint8(17);
             const cmd = view.getUint8(18 + optLen);
             if (cmd !== 1 && cmd !== 2) return;
@@ -224,7 +225,7 @@ async function handleWebSocket(request) {
                 addr = ipv6.join(':');
             } else return;
             if (addr.includes(atob('c3BlZWQuY2xvdWRmbGFyZS5jb20='))) throw new Error('Access');
-            const header = new Uint8Array([data[0], 0]);
+            const header = new Uint8Array([version, 0]); // 使用提取的版本号
             const payload = data.slice(pos);
 
             // UDP DNS
@@ -429,11 +430,13 @@ async function readVlessHeader(reader) {
 
         const headerLen = hostIndex + hostLen;
         const data = buffer.slice(headerLen, offset);
+        const version = buffer[0]; // 提取版本号
         return {
             hostname,
             port,
             data,
-            resp: new Uint8Array([buffer[0], 0]),
+            version,
+            resp: new Uint8Array([version, 0]), // 使用实际版本号而不是 buffer[0]
             reader
         };
     }

--- a/snippet/t12.js
+++ b/snippet/t12.js
@@ -81,7 +81,6 @@ async function 升级WS请求(访问请求) {
     const 创建WS接口 = new WebSocketPair();
     const [客户端, WS接口] = Object.values(创建WS接口);
     WS接口.accept();
-    WS接口.send(new Uint8Array([0, 0]));
     处理WS请求(访问请求, WS接口)
     return new Response(null, { status: 101, webSocket: 客户端 }); //一切准备就绪后，回复客户端WS连接升级成功
 }
@@ -109,6 +108,8 @@ function 转换WS数据头为二进制数据(WS数据头) {
 async function 解析VL标头(二进制数据, WS接口, TCP接口) {
     let 识别地址类型, 访问地址, 地址长度;
     try {
+        const 版本号 = 二进制数据[0];
+        WS接口.send(new Uint8Array([版本号, 0]));
         const 获取数据定位 = 二进制数据[17];
         const 提取端口索引 = 18 + 获取数据定位 + 1;
         const 访问端口 = new DataView(二进制数据.buffer, 提取端口索引, 2).getUint16(0);


### PR DESCRIPTION
This pull request introduces a consistent approach to handling protocol version bytes across multiple WebSocket-based snippets (`ak.js`, `my.js`, `t12.js`, `t13.js`), ensuring that the actual version byte from the client is echoed back in the server handshake. It also includes minor documentation updates and a UI string fix.

**Protocol handshake and version byte handling:**

* Updated `ak.js`, `my.js`, `t12.js`, and `t13.js` to extract the protocol version byte from the client's initial message and send it back in the handshake, replacing the previous hardcoded `[0, 0]`. This ensures better protocol compatibility and future extensibility. [[1]](diffhunk://#diff-a38c2b4a5c42e3500f252eb2c18328f9793024c587ae6a581f141c605f8b19e4L72-R72) [[2]](diffhunk://#diff-a38c2b4a5c42e3500f252eb2c18328f9793024c587ae6a581f141c605f8b19e4R95) [[3]](diffhunk://#diff-a38c2b4a5c42e3500f252eb2c18328f9793024c587ae6a581f141c605f8b19e4R105-R106) [[4]](diffhunk://#diff-a38c2b4a5c42e3500f252eb2c18328f9793024c587ae6a581f141c605f8b19e4R133) [[5]](diffhunk://#diff-a38c2b4a5c42e3500f252eb2c18328f9793024c587ae6a581f141c605f8b19e4L166-R171) [[6]](diffhunk://#diff-d2e01e8ecf7c6918b598591cca3070f4eedf81802b93199cdf1bb0c7c90f25c5R203) [[7]](diffhunk://#diff-d2e01e8ecf7c6918b598591cca3070f4eedf81802b93199cdf1bb0c7c90f25c5L227-R228) [[8]](diffhunk://#diff-d2e01e8ecf7c6918b598591cca3070f4eedf81802b93199cdf1bb0c7c90f25c5R433-R439) [[9]](diffhunk://#diff-68e671f18d3f4325f784ec32267649aaa2b634d1edff13622eee30a19eee737eL84) [[10]](diffhunk://#diff-68e671f18d3f4325f784ec32267649aaa2b634d1edff13622eee30a19eee737eR111-R112) [[11]](diffhunk://#diff-ae6dfef2b8c1ad377ce3cd246fbdcc05f061325881e5af08f6caab669e008519L70) [[12]](diffhunk://#diff-ae6dfef2b8c1ad377ce3cd246fbdcc05f061325881e5af08f6caab669e008519R94-R97)

**Minor improvements and fixes:**

* Added a new contributor to the `README.md` acknowledgments.
* Corrected a UI string in the source selection dropdown to clarify that "天书13源码" does not support "ed配置" (removed "不支持ios客户端").
* Added a TypeScript ignore comment for a property assignment in `ak.js` to suppress type checking errors. WebSocket 连接逻辑，确保使用实际版本号。