### PR TITLE
更新 ed 参数处理逻辑，支持 ak 源码；调整相关注释以提高代码可读性

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -3120,13 +3120,13 @@ async function subHtml(request, hostLength = 0, FileName, subProtocol, subConver
             const enableEd = document.getElementById('enableEd').checked;
             const skipCertVerify = document.getElementById('skipCertVerify').checked;
             
-            // 添加 ed=2560 参数（如果启用且不是天书13源码）
+            // 添加 ed=2560 参数（如果启用且不是天书13或ak源码）
             if (enableEd) {
-                // 检查是否为天书13源码
+                // 检查是否为天书13或ak源码
                 const selectedSource = getSelectedSnippetSource();
                 const isSnippetsTab = activeTab && activeTab.id === 'snippets-tab';
                 
-                if (!isSnippetsTab || selectedSource !== 't13') {
+                if (!isSnippetsTab || (selectedSource !== 't13' && selectedSource !== 'ak')) {
                     params.append('ed', '2560');
                 }
             }
@@ -3608,13 +3608,13 @@ async function subHtml(request, hostLength = 0, FileName, subProtocol, subConver
                 const activeTab = document.querySelector('.tab-button.active');
                 const isSnippetsTab = activeTab && activeTab.id === 'snippets-tab';
                 
-                if (isSnippetsTab && selectedSource === 't13') {
+                if (isSnippetsTab && (selectedSource === 't13' || selectedSource === 'ak')) {
                     // 天书13源码不支持ed参数，禁用选项
                     enableEdCheckbox.disabled = true;
                     enableEdCheckbox.checked = false;
                     enableEdOption.style.opacity = '0.5';
                     enableEdOption.style.pointerEvents = 'none';
-                    enableEdOption.title = '天书13源码不支持ed参数配置';
+                    enableEdOption.title = '天书13、ak源码不支持ed参数配置';
                 } else {
                     // 其他情况启用选项
                     enableEdCheckbox.disabled = false;


### PR DESCRIPTION
This pull request updates the logic for handling the `ed=2560` parameter and the associated UI option in the `subHtml` function within `_worker.js`. The main change is to treat both "天书13" (`t13`) and "ak" sources the same way, ensuring the `ed` parameter is not added and the option is disabled for either source.

Parameter handling updates:

* The check for adding the `ed=2560` parameter now excludes both `t13` and `ak` snippet sources, preventing the parameter from being appended in these cases.

UI logic updates:

* The UI logic that disables and greys out the "Enable Ed" option now applies to both `t13` and `ak` sources, and the tooltip message has been updated accordingly.