### PR TITLE
Beta

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -12,7 +12,7 @@ export default {
         }
         let subConfig = env.SUBCONFIG || 'https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/config/ACL4SSR_Online_Mini_MultiMode.ini';
         const proxyIP = env.PROXYIP || null;
-        let ips = ['3Q.bestip-one.cf.090227.xyz#感谢白嫖哥t.me/bestip_one'];
+        let ips = ['3Q.bestip-one.cf.090227.xyz#加入我的频道t.me/CMLiussss解锁更多优选节点'];
         if (env.ADD) ips = await 整理成数组(env.ADD);
         let FileName = env.SUBNAME || 'BPSUB';
         let EndPS = env.PS || '';


### PR DESCRIPTION
This pull request makes several updates to the `_worker.js` file, focusing on simplifying the deployment options in the frontend UI (removing Workers and Pages tabs to only keep Snippets), updating endpoint URLs and labels, and improving cache handling for configuration files. The changes also enforce consistent use of the Snippets deployment tab throughout the UI logic.

**Frontend UI simplification and consistency:**
- Removed "Workers" and "Pages" deployment tabs, leaving only the "Snippets" tab visible and active by default. All related logic now forces the use of the Snippets tab for deployment instructions and state restoration. [[1]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL1986-R1992) [[2]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL2072-R2066) [[3]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL2716-R2713) [[4]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL2806-R2803) [[5]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL4076-R4070)

**Endpoint and label updates:**
- Changed the default proxy endpoint label and value from `https://subapi.cmliussss.net` to `https://subapi.090227.xyz` and updated the default IP label to promote a different Telegram channel. [[1]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL15-R15) [[2]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL43-R43)

**Backend route and parameter handling:**
- Updated backend path construction logic for proxy and socks5/http parameters, simplifying and standardizing URL patterns for these features.

**Configuration caching improvement:**
- Added a timestamp query parameter to configuration file fetch requests (`subapi.json` and `subconfig.json`) to prevent browser caching and ensure the latest configuration is always loaded. [[1]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bR2401-R2406) [[2]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL2425-R2421)

**Minor documentation/content change:**
- Removed an outdated note about "天书13" not supporting the `ed` parameter from the help section.