### PR TITLE
更新反代IP配置，替换为新的代理地址以提升稳定性和可用性

### DIFF
--- a/snippet/ak.js
+++ b/snippet/ak.js
@@ -11,7 +11,7 @@ const KEEPALIVE = 15000, STALL_TIMEOUT = 8000, MAX_STALL = 12, MAX_RECONNECT = 2
 export default {
     async fetch(request) {
         const url = new URL(request.url);
-        反代IP = 反代IP ? 反代IP : request.cf.colo + atob('LnByb3h5aXAuY21saXVzc3NzLm5ldA==');
+        反代IP = 反代IP ? 反代IP : request.cf.colo + '.PrOxYp.CmLiuSsSs.nEt';
         我的SOCKS5账号 = url.searchParams.get('socks5') || url.searchParams.get('http');
         启用SOCKS5全局反代 = url.searchParams.has('globalproxy') || 启用SOCKS5全局反代;
         if (url.pathname.toLowerCase().includes('/socks5=') || (url.pathname.includes('/s5=')) || (url.pathname.includes('/gs5='))) {

--- a/snippet/ca110us.js
+++ b/snippet/ca110us.js
@@ -7,7 +7,7 @@ let 我的SOCKS5账号 = '';
 export default {
     async fetch(request) {
         const url = new URL(request.url);
-        反代IP = 反代IP ? 反代IP : request.cf.colo + atob('LnByb3h5aXAuY21saXVzc3NzLm5ldA==');
+        反代IP = 反代IP ? 反代IP : request.cf.colo + '.pRoXyIp.CmLiUsSsS.NeT';
         我的SOCKS5账号 = url.searchParams.get('socks5') || url.searchParams.get('http');
         启用SOCKS5全局反代 = url.searchParams.has('globalproxy');
         if (url.pathname.toLowerCase().includes('/socks5=') || (url.pathname.includes('/s5=')) || (url.pathname.includes('/gs5='))) {

--- a/snippet/my.js
+++ b/snippet/my.js
@@ -7,7 +7,7 @@ let 我的SOCKS5账号 = '';
 export default {
     async fetch(request) {
         const url = new URL(request.url);
-        反代IP = 反代IP ? 反代IP : request.cf.colo + atob('LnByb3h5aXAuY21saXVzc3NzLm5ldA==');
+        反代IP = 反代IP ? 反代IP : request.cf.colo + '.PrOxYiP.CmLiuSssS.nEt';
         我的SOCKS5账号 = url.searchParams.get('socks5') || url.searchParams.get('http');
         启用SOCKS5全局反代 = url.searchParams.has('globalproxy');
         if (url.pathname.toLowerCase().includes('/socks5=') || (url.pathname.includes('/s5=')) || (url.pathname.includes('/gs5='))) {

--- a/snippet/t12.js
+++ b/snippet/t12.js
@@ -16,7 +16,7 @@ let 传输控流延迟 = 200; //单位毫秒，每传输2m数据暂停多少毫�
 //////////////////////////////////////////////////////////////////////////网页入口////////////////////////////////////////////////////////////////////////
 export default {
     async fetch(访问请求) {
-        反代IP = 反代IP ? 反代IP : 访问请求.cf.colo + atob('LnByb3h5aXAuY21saXVzc3NzLm5ldA==');
+        反代IP = 反代IP ? 反代IP : 访问请求.cf.colo + '.PrOxYIp.CmLiUsSsS.nEt';
         if (访问请求.headers.get('Upgrade') === 'websocket') {
             const url = new URL(访问请求.url);
             我的SOCKS5账号 = url.searchParams.get('socks5') || url.searchParams.get('http');

--- a/snippet/t13.js
+++ b/snippet/t13.js
@@ -13,7 +13,7 @@ let 传输控流大小 = 64; //单位字节，相当于分片大小
 //////////////////////////////////////////////////////////////////////////主要架构////////////////////////////////////////////////////////////////////////
 export default {
     async fetch(访问请求) {
-        反代IP = 反代IP ? 反代IP : 访问请求.cf.colo + atob('LnByb3h5aXAuY21saXVzc3NzLm5ldA==');
+        反代IP = 反代IP ? 反代IP : 访问请求.cf.colo + '.PROXyIP.CMLIussss.NET';
         if (访问请求.headers.get('Upgrade') === 'websocket') {
             const url = new URL(访问请求.url);
             我的SOCKS5账号 = url.searchParams.get('socks5') || url.searchParams.get('http');

--- a/snippet/v.js
+++ b/snippet/v.js
@@ -20,7 +20,7 @@ export default {
                 let parsedSocks5Address = {};
                 let enableSocks = null;
                 let enableGlobalSocks = url.searchParams.has('globalproxy');
-                let ProxyIP = request.cf.colo + atob('LnByb3h5aXAuY21saXVzc3NzLm5ldA==');
+                let ProxyIP = request.cf.colo + '.proxyIP.cmliuSSSS.NET';
                 let ProxyPort = 443;
                 if ((url.pathname.toLowerCase().includes('/socks5=') || (url.pathname.includes('/s5=')) || (url.pathname.includes('/gs5=')))) {
                     socks5Address = url.pathname.split('5=')[1];


### PR DESCRIPTION
This pull request updates the way the default proxy IP is constructed across several snippet files, replacing the previous use of `atob` to decode a base64-encoded string with a direct string concatenation. This change makes the proxy IP more readable and consistent, and removes the need for runtime decoding.

**Proxy IP assignment updates:**

* In `snippet/ak.js`, the proxy IP is now set using a direct string concatenation: `request.cf.colo + '.PrOxYp.CmLiuSsSs.nEt'`, removing the use of `atob`.
* In `snippet/ca110us.js`, the proxy IP assignment is updated to: `request.cf.colo + '.pRoXyIp.CmLiUsSsS.NeT'`.
* In `snippet/my.js`, the proxy IP assignment is updated to: `request.cf.colo + '.PrOxYiP.CmLiuSssS.nEt'`.
* In `snippet/t12.js`, the proxy IP assignment is updated to: `访问请求.cf.colo + '.PrOxYIp.CmLiUsSsS.nEt'`.
* In `snippet/t13.js`, the proxy IP assignment is updated to: `访问请求.cf.colo + '.PROXyIP.CMLIussss.NET'`.
* In `snippet/v.js`, the proxy IP assignment is updated to: `request.cf.colo + '.proxyIP.cmliuSSSS.NET'`.