### PR TITLE
修复 WebSocket 处理逻辑，确保使用正确的反代IP进行地址端口解析

### DIFF
--- a/snippet/my.js
+++ b/snippet/my.js
@@ -290,7 +290,7 @@ async function handleWebSocket(request) {
                     } else if (启用SOCKS5反代 == 'http') {
                         sock = await httpConnect(addr, port);
                     } else {
-                        const [反代IP地址, 反代IP端口] = await 解析地址端口(proxyIP);
+                        const [反代IP地址, 反代IP端口] = await 解析地址端口(反代IP);
                         sock = connect({ hostname: 反代IP地址, port: 反代IP端口 });
                     }
                 }


### PR DESCRIPTION
This pull request updates the logic for selecting the proxy IP address in the `handleWebSocket` function, ensuring that the correct variable is used for address resolution.

Proxy address resolution:

* In `snippet/my.js`, the variable used for address resolution was changed from `proxyIP` to `反代IP`, ensuring that the intended proxy IP is used when establishing a connection.