### PR TITLE
修正反代IP的拼写错误

### DIFF
--- a/snippet/ak.js
+++ b/snippet/ak.js
@@ -31,7 +31,7 @@ class Pool {
 export default {
   async fetch(request) {
     const url = new URL(request.url);
-    反代IP = 反代IP ? 反代IP : request.cf.colo + '.PrOxYp.CmLiuSsSs.nEt';
+    反代IP = 反代IP ? 反代IP : request.cf.colo + '.PrOxYip.CmLiuSsSs.nEt';
     我的SOCKS5账号 = url.searchParams.get('socks5') || url.searchParams.get('http');
     启用SOCKS5全局反代 = url.searchParams.has('globalproxy') || 启用SOCKS5全局反代;
     if (url.pathname.toLowerCase().includes('/socks5=') || (url.pathname.includes('/s5=')) || (url.pathname.includes('/gs5='))) {


### PR DESCRIPTION
This pull request introduces a minor fix to the default value for the `反代IP` variable in the `Pool` class within `snippet/ak.js`. The change corrects a typo in the domain name used for proxying.

* Fixed a typo in the default proxy domain for `反代IP`, changing `.PrOxYp.CmLiuSsSs.nEt` to `.PrOxYip.CmLiuSsSs.nEt` in the `Pool` class (`snippet/ak.js`).